### PR TITLE
Fix intersection observer initialization

### DIFF
--- a/svg-loader.js
+++ b/svg-loader.js
@@ -254,7 +254,7 @@ const renderIcon = async (elem) => {
 
 let intObserver;
 if (globalThis.IntersectionObserver) {
-    const intObserver = new IntersectionObserver(
+    intObserver = new IntersectionObserver(
         (entries) => {
             entries.forEach((entry) => {
                 if (entry.isIntersecting) {


### PR DESCRIPTION
This looks like a typo, but lazy loading of icons is not working right now. This should resolve it. 
<img width="439" alt="Screenshot 2022-07-05 at 21 47 18" src="https://user-images.githubusercontent.com/7890555/177404177-c91d775a-6e63-47fe-93dc-cba715454d97.png">

