### PR TITLE
make build:cp compatible with w/ windows 

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "scripts": {
         "postinstall": "npm-run-all build:*",
         "build:js": "cross-env NODE_ENV=production webpack build",
-        "build:cp": "cp ./dist/svg-loader.min.js ./svg-loader.min.js || copy ./dist/svg-loader.min.js ./svg-loader.min.js ",
+        "build:cp": "npx copyfiles ./dist/svg-loader.min.js ./svg-loader.min.js",
         "build": "npm-run-all build:*",
         "dev:watch": "webpack watch --mode development",
         "dev:http": "cd test && http-server",
@@ -25,6 +25,7 @@
         "husky": "^8.0.3"
     },
     "dependencies": {
+        "copyfiles":"^2.4.1",
         "cross-env": "^7.0.3",
         "idb-keyval": "^6.2.0",
         "npm-run-all": "^4.1.5",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "scripts": {
         "postinstall": "npm-run-all build:*",
         "build:js": "cross-env NODE_ENV=production webpack build",
-        "build:cp": "npx cpr --overwrite ./dist/svg-loader.min.js ./svg-loader.min.js",
+        "build:cp": "npx cpr ./dist/svg-loader.min.js ./svg-loader.min.js --overwrite",
         "build": "npm-run-all build:*",
         "dev:watch": "webpack watch --mode development",
         "dev:http": "cd test && http-server",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "scripts": {
         "postinstall": "npm-run-all build:*",
         "build:js": "cross-env NODE_ENV=production webpack build",
-        "build:cp": "npx cpr ./dist/svg-loader.min.js ./svg-loader.min.js",
+        "build:cp": "npx cpr --overwrite ./dist/svg-loader.min.js ./svg-loader.min.js",
         "build": "npm-run-all build:*",
         "dev:watch": "webpack watch --mode development",
         "dev:http": "cd test && http-server",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "scripts": {
         "postinstall": "npm-run-all build:*",
         "build:js": "cross-env NODE_ENV=production webpack build",
-        "build:cp": "npx copyfiles ./dist/svg-loader.min.js ./svg-loader.min.js",
+        "build:cp": "npx cpr ./dist/svg-loader.min.js ./svg-loader.min.js",
         "build": "npm-run-all build:*",
         "dev:watch": "webpack watch --mode development",
         "dev:http": "cd test && http-server",
@@ -25,7 +25,7 @@
         "husky": "^8.0.3"
     },
     "dependencies": {
-        "copyfiles":"^2.4.1",
+        "cpr":"^3.0.1",
         "cross-env": "^7.0.3",
         "idb-keyval": "^6.2.0",
         "npm-run-all": "^4.1.5",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "scripts": {
         "postinstall": "npm-run-all build:*",
         "build:js": "cross-env NODE_ENV=production webpack build",
-        "build:cp": "cp ./dist/svg-loader.min.js ./svg-loader.min.js",
+        "build:cp": "cp ./dist/svg-loader.min.js ./svg-loader.min.js || copy ./dist/svg-loader.min.js ./svg-loader.min.js ",
         "build": "npm-run-all build:*",
         "dev:watch": "webpack watch --mode development",
         "dev:http": "cd test && http-server",


### PR DESCRIPTION
```diff
- "build:cp": "cp ./dist/svg-loader.min.js ./svg-loader.min.js"
+ "build:cp": "npx cpr ./dist/svg-loader.min.js ./svg-loader.min.js --overwrite",
```
fix for issue:  #32 




