### PR TITLE
Fix #22 : throw custom error event on SVG load failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,8 +211,21 @@ When the SVG has been loaded an event `iconload` is triggered. This can be used 
 </script>
 ```
 
+### Using the `iconloaderror` event
+When an error occurs during loading of the SVG file, an `iconloaderror` event is triggered, passing the error message as the event's `detail`.
+
+```html
+<svg data-src="https://unpkg.com/@mdi/svg@5.9.55/svg/this-svg-does-not-exist.svg"></svg>
+
+<script>
+  window.addEventListener('iconloaderror', (e) => {
+    console.error('Failed to load SVG:', e.detail);
+  });
+</script>
+```
+
 ### Using Events in React
-React doesn't support custom events out of the box. To circumvent this limitation, you can [refs](https://reactjs.org/docs/refs-and-the-dom.html).
+React doesn't support custom events out of the box. To circumvent this limitation, you can use [refs](https://reactjs.org/docs/refs-and-the-dom.html).
 
 ```jsx
 class MyApp extends React.Component {
@@ -226,7 +239,10 @@ class MyApp extends React.Component {
   componentDidMount() {
     this.ref.current.addEventListener('iconload', () => {
       console.log("Icon Loaded", this.ref.current)
-    })
+    });
+    this.ref.current.addEventListener('iconloaderror', (e) => {
+      console.error('Failed to load SVG:', e.detail);
+    });
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -224,6 +224,13 @@ When an error occurs during loading of the SVG file, an `iconloaderror` event is
 </script>
 ```
 
+Similarly to the `iconload` event, `iconloaderror` can also be used with an inline function, which will have access to an `error` argument (the `Error` object that was thrown):
+```html
+<svg
+  data-src="https://unpkg.com/@mdi/svg@5.9.55/svg/cog.svg"
+  oniconloaderror="console.log('Error loading SVG:', error.toString())"></svg>
+```
+
 ### Using Events in React
 React doesn't support custom events out of the box. To circumvent this limitation, you can use [refs](https://reactjs.org/docs/refs-and-the-dom.html).
 

--- a/svg-loader.js
+++ b/svg-loader.js
@@ -270,6 +270,11 @@ const renderIcon = async (elem) => {
             })
             .catch((e) => {
                 console.error(e);
+                const event = new CustomEvent('iconloaderror', {
+                    bubbles: true,
+                    detail: t.toString(),
+                });
+                elem.dispatchEvent(event);
             })
             .finally(() => {
                 delete requestsInProgress[src];

--- a/svg-loader.js
+++ b/svg-loader.js
@@ -272,7 +272,7 @@ const renderIcon = async (elem) => {
                 console.error(e);
                 const event = new CustomEvent('iconloaderror', {
                     bubbles: true,
-                    detail: t.toString(),
+                    detail: e.toString(),
                 });
                 elem.dispatchEvent(event);
             })

--- a/svg-loader.js
+++ b/svg-loader.js
@@ -196,7 +196,7 @@ const renderBody = (elem, options, body) => {
         // no way to specify the context for execution. So, `this` in the attribute
         // will point to `window` instead of the element itself. 
         //
-        // Here we are recycling a rarely used GlobalEventHandler 'onloadedmetadata'
+        // Here we are recycling a rarely used GlobalEventHandler 'onauxclick'
         // and offloading the execution to the browser. This is a hack, but because
         // the event doesn't bubble, it shouldn't affect anything else in the code. 
         elem.setAttribute('onauxclick', elem.getAttribute('oniconload'));
@@ -275,6 +275,11 @@ const renderIcon = async (elem) => {
                     detail: e.toString(),
                 });
                 elem.dispatchEvent(event);
+                if(elem.getAttribute('oniconloaderror')){
+                    // the oniconloaderror inline function will have access to an `error` argument
+                    const loadErrorFunction = Function("error", elem.getAttribute('oniconloaderror'));
+                    loadErrorFunction(e);
+                }
             })
             .finally(() => {
                 delete requestsInProgress[src];

--- a/test/index.html
+++ b/test/index.html
@@ -46,6 +46,15 @@
         });
     </script>
 
+    <div class="heading">Icon load error event (see console)</div>
+    <svg data-src="https://unpkg.com/@mdi/svg@5.9.55/svg/this-svg-does-not-exist.svg"></svg>
+
+    <script>
+        window.addEventListener('iconloaderror', (e) => {
+            console.error('Error event fired:', e.detail);
+        });
+    </script>
+
     <div class="heading">Icon using doctype declaration</div>
     <svg data-src="/icons/cog-with-doctype.svg" fill="green"></svg>
 


### PR DESCRIPTION
There is currently no easy way to catch errors when loading an SVG file.
The error is logged to the console and nothing else is done with it.
For example, if you load images dynamically —as is my case— and the URL returns a 404 or some other error, you might want to be able to show users an error message.

I implemented this simply by dispatching a `CustomEvent` like it is done [for the `iconload` event](https://github.com/shubhamjain/svg-loader/blob/main/svg-loader.js#L193C43-L210).
I followed the naming convention with `iconloaderror`.

Two questions/doubts I have:
- I originally implemented this behind a flag (requiring `data-error="enabled"` property on the svg element) but decided against it after looking at the implementation for the `iconload` event
- I was unsure as to whether an `oniconloaderror` inline function string should be implemented as well (as with `oniconload`). My use-case is usage with React and I haven't tested the inline function events, and I might need some help with that.


Please let me know if that should be implemented or if there is anything else you would like to see improved or changed.